### PR TITLE
Bump add-on version to 1.1.76

### DIFF
--- a/addons/ktor_app/config.yaml
+++ b/addons/ktor_app/config.yaml
@@ -1,5 +1,5 @@
 name: "Ktor App"
-version: "1.1.75"
+version: "1.1.76"
 slug: "ktor_app"
 description: "Ktor backend application with Angular frontend for recipes, shopping lists, and more"
 arch:


### PR DESCRIPTION
Generated from successful CI run https://github.com/MaximilianSeewald/KtorFramework/actions/runs/25828845744.

Auto-merge is enabled, but branch protection and required checks decide when it lands.