### PR TITLE
Disable SecurityHeaders if Swagger is enabled

### DIFF
--- a/backend/src/main/kotlin/KtorManager.kt
+++ b/backend/src/main/kotlin/KtorManager.kt
@@ -50,7 +50,9 @@ class KtorManager {
         application.install(ContentNegotiation) {
             json()
         }
-        application.install(SecurityHeaders)
+        if (!BackendConfig.swaggerEnabled){
+            application.install(SecurityHeaders)
+        }
         application.install(StatusPages) {
             exception<Throwable> { call, cause ->
                 val requestId = call.callId ?: "unknown"


### PR DESCRIPTION
Swagger does not work with defined Content Security Policy